### PR TITLE
Added docstring to the SchedulerType class

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -411,6 +411,23 @@ def speed_metrics(split, start_time, num_samples=None, num_steps=None, num_token
 
 
 class SchedulerType(ExplicitEnum):
+    """
+    Scheduler names for the parameter `lr_scheduler_type` in the `TrainingArguments` constructor class.
+    By default, it uses "linear". Internally, this will get `get_linear_schedule_with_warmup` scheduler in the `Trainer` class. 
+    All possible names and their corresponding schedulers are as follows,
+    
+    "linear" = get_linear_schedule_with_warmup
+    "cosine" = get_cosine_schedule_with_warmup
+    "cosine_with_restarts" = get_cosine_with_hard_restarts_schedule_with_warmup
+    "polynomial" = get_polynomial_decay_schedule_with_warmup
+    "constant" =  get_constant_schedule
+    "constant_with_warmup" = get_constant_schedule_with_warmup
+    "inverse_sqrt" = get_inverse_sqrt_schedule
+    "reduce_lr_on_plateau" = get_reduce_on_plateau_schedule
+    "cosine_with_min_lr" = get_cosine_with_min_lr_schedule_with_warmup
+    "warmup_stable_decay" = get_wsd_schedule
+    
+    """
     LINEAR = "linear"
     COSINE = "cosine"
     COSINE_WITH_RESTARTS = "cosine_with_restarts"


### PR DESCRIPTION
The docstring for the class `SchedulerType`  is missing. Therefore, the AutoDoc only displays the `__call__` signature of `enum.EnumType`  base class which is not helpful.  Hence, added the docstring that lists out all the available names and the scheduler types they are mapped to. 

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).



## Who can review?

Documentation: @stevhliu

